### PR TITLE
ci: 🎡 fix permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,4 +13,7 @@ jobs:
 
   deploy:
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     uses: ./.github/workflows/_deploy.yml

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -11,4 +11,7 @@ jobs:
 
   deploy:
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     uses: ./.github/workflows/_deploy.yml


### PR DESCRIPTION
The nested job 'deploy' is requesting 'pages: write, id-token: write',
but is only allowed 'pages: none, id-token: none'.

✅ Closes: #14